### PR TITLE
Prepare for jsserve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.jl.*.cov
 *.jl.mem
 .vscode/settings.json
+
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,10 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 GeoJSON = "61d90e0f-e114-555e-ac52-39dfb47a3ef9"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+JSServe = "824d6782-a2ef-11e9-3a09-e5662e0c26f9"
+Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 TileProviders = "263fe934-28e1-4ae9-998a-c2629c5fede6"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
-Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 GeoJSON = "61d90e0f-e114-555e-ac52-39dfb47a3ef9"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Leaflet
 
-[![](https://img.shields.io/badge/docs-stable-blue.svg)]()
-[![](https://img.shields.io/badge/docs-dev-blue.svg)]()
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://supergrobi.github.io/Leaflet.jl/stable)
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://supergrobi.github.io/Leaflet.jl/dev)
 [![CI](https://github.com/SuperGrobi/Leaflet.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/SuperGrobi/Leaflet.jl/actions/workflows/CI.yml)
 
 LeafletJS maps for Julia.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,24 @@
 # Leaflet
 
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaGeo.github.io/Leaflet.jl/stable)
-[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaGeo.github.io/Leaflet.jl/dev)
-[![CI](https://github.com/JuliaGeo/Leaflet.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaGeo/Leaflet.jl/actions/workflows/CI.yml)
-[![codecov.io](http://codecov.io/github/JuliaGeo/Leaflet.jl/coverage.svg?branch=main)](http://codecov.io/github/yeesian/Leaflet.jl?branch=main)
+[![](https://img.shields.io/badge/docs-stable-blue.svg)]()
+[![](https://img.shields.io/badge/docs-dev-blue.svg)]()
+[![CI](https://github.com/SuperGrobi/Leaflet.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/SuperGrobi/Leaflet.jl/actions/workflows/CI.yml)
 
 LeafletJS maps for Julia.
 
-This package integrates with WebIO.jl to render leaflet maps for outputs like 
-Blink.jl, Mux.jl, and for Jupyter notebooks.
+This package integrates with JSServe.jl to render leaflet maps to backends able to deal with html.
 
 All [GeoInterface.jl](https://github.com/JuliaGeo/GeoInterface.jl) compatible geometries can be displayed as layers.
 
-A basic example, where we use GADM to download a country boundary shapefile,
+A basic (non-working) example, where we use GADM to download a country boundary shapefile,
 and plot them over the CARTO `:dark_nolabels` base layers.
 
 ```julia
-using Leaflet, Blink, GADM
+using Leaflet, Electron, GADM, JSServe
+JSServe.use_electron_display()
 layers = Leaflet.Layer.([GADM.get("CHN").geom[1], GADM.get("JPN").geom[1]]; color=:orange); 
 provider = Providers.CartoDB()
 m = Leaflet.Map(; layers, provider, zoom=3, height=1000, center=[30.0, 120.0]);
-w = Blink.Window(; body=m)
+display(m)
 ```
 ![](docs/img/example-fs8.png)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,19 +3,19 @@ using Documenter
 
 makedocs(;
     modules=[Leaflet],
-    repo="https://github.com/JuliaGeo/Leaflet.jl/blob/{commit}{path}#{line}",
+    repo="https://github.com/SuperGrobi/Leaflet.jl/blob/{commit}{path}#{line}",
     sitename="Leaflet.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://JuliaGeo.github.io/Leaflet.jl",
-        assets=String[],
+        canonical="https://SuperGrobi.github.io/Leaflet.jl",
+        assets=String[]
     ),
     pages=[
         "Home" => "index.md",
-    ],
+    ]
 )
 
 deploydocs(;
-    repo="github.com/JuliaGeo/Leaflet.jl",
-    devbranch="main",
+    repo="github.com/SuperGrobi/Leaflet.jl",
+    devbranch="move_to_jsserve"
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ CurrentModule = Leaflet
 
 # Leaflet
 
-Documentation for [Leaflet](https://github.com/JuliaGeo/Leaflet.jl).
+Documentation for [Leaflet](https://github.com/SuperGrobi/Leaflet.jl).
 
 ```@index
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,7 +38,7 @@ map_id_dict = ee.Image(image).getMapId(visParams)
 map_url = map_id_dict["tile_fetcher"].url_format
 
 # Define a leaflet provider
-ee_provider = Leaflet.Provider(
+ee_provider = Providers.Provider(
     map_url,
     Dict{Symbol,Any}(
         :maxZoom => 20,

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -37,7 +37,7 @@ visParams = Dict(
 map_id_dict = ee.Image(image).getMapId(visParams)
 map_url = map_id_dict["tile_fetcher"].url_format
 
-# Define a leaflet provider
+# Define a TileProviders provider
 ee_provider = Providers.Provider(
     map_url,
     Dict{Symbol,Any}(

--- a/src/Leaflet.jl
+++ b/src/Leaflet.jl
@@ -6,9 +6,9 @@ module Leaflet
     include_dependency(path)
     read(path, String)
 end Leaflet
-    
+
 import Colors, GeoInterface, GeoJSON, JSON3, UUIDs
-using Dates, WebIO
+using WebIO
 using JSServe, Observables
 
 import TileProviders as Providers

--- a/src/Leaflet.jl
+++ b/src/Leaflet.jl
@@ -9,6 +9,7 @@ end Leaflet
     
 import Colors, GeoInterface, GeoJSON, JSON3, UUIDs
 using Dates, WebIO
+using JSServe, Observables
 
 import TileProviders as Providers
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,3 @@
-using Dates
 using GADM
 using Leaflet
 using Test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,24 +5,22 @@ using Test
 using WebIO
 
 providers = (
-    Leaflet.OpenStreetMap(),
-    Leaflet.OpenStreetMap(:France),
-    Leaflet.OpenStreetMap(:DE),
-    Leaflet.OpenTopoMap(),
-    Leaflet.CartoDB(:dark_nolabels),
-    Leaflet.Esri(),
-    Leaflet.Stamen(),
-    Leaflet.Stamen(:watercolor),
-    Leaflet.CartoDB(:dark_all),
-    Leaflet.Google(:hybrid),
-    Leaflet.MapBox(; tileset_id="username.id", access_token="sometoken"),
-    Leaflet.Jawg(; access_token="sometoken"),
-    Leaflet.Thunderforest(; apikey="someapikey"),
-    Leaflet.OpenWeatherMap(:clouds; apikey="someapikey"),
-    Leaflet.OpenWeatherMap(:clouds; apikey="someapikey"),
-    Leaflet.NASAGIBS(:VIIRS_CityLights_2012),
-    Leaflet.NASAGIBS(:AMSRE_Brightness_Temp_89H_Day; date=Date(2010, 05, 07)),
-    Leaflet.Provider("http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"),
+    Providers.OpenStreetMap(),
+    Providers.OpenStreetMap(:France),
+    Providers.OpenStreetMap(:DE),
+    Providers.OpenTopoMap(),
+    Providers.CartoDB(:DarkMatterNoLabels),
+    Providers.Esri(),
+    Providers.Stamen(),
+    Providers.Stamen(:Watercolor),
+    Providers.CartoDB(:DarkMatter),
+    Providers.Google(:hybrid),  # I think variants should either be capitalised or not... probably too late to fix that without beeing breaking
+    Providers.MapBox(; accesstoken="sometoken"),
+    Providers.Jawg(; accesstoken="sometoken"),
+    Providers.Thunderforest(; apikey="someapikey"),
+    Providers.OpenWeatherMap(:Clouds),
+    Providers.NASAGIBS(:ViirsEarthAtNight2012),
+    Providers.Provider("http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"),
 )
 
 # We are not actually testing that the web interface shows the map,
@@ -30,15 +28,16 @@ providers = (
 # actually works in a browser is a much bigger task.
 for provider in providers
     # Make a country outline Layer
-    layers = Leaflet.Layer(GADM.get("MUS").geom[1]; 
-        color="#ff0201", 
+    layers = Leaflet.Layer(GADM.get("MUS").geom[1];
+        color="#ff0201",
         opacity=0.6,
-        fill_opacity=0.2,
+        fill_opacity=0.2
     )
     # Combine into a Map
-    m = Leaflet.Map(; layers, provider, zoom=3, height=1000);
+    m = Leaflet.Map(; layers, provider, zoom=3, height=1000)
     # Render as html/javascript
     interface = WebIO.render(m)
+    @test true
 end
 
 # Manual test


### PR DESCRIPTION
- Cleaned up what was left from moving out the tile providers to their own package
- set up docs to build and deploy for this package
- added jsserve and observables
- removed dates
- updated docs and readme to somewhat reflect what we are trying to do here.